### PR TITLE
Prevent button flicker on hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -65,8 +65,7 @@ a:visited {
 }
 
 .button:hover {
-  margin-top: -2px;
-  margin-bottom: 2px;
+  transform: translateY(-2px);
   color: white;
   background-color: #878E9D;
   box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
The transform property doesn't move the button hitbox, which prevents the button from moving out from under the cursor, then back again repeatedly.